### PR TITLE
Run prisma generate when deploying to Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.9.0",


### PR DESCRIPTION
I was receiving this error message when testing the deployment:

> Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the `prisma generate` command during the build process.
> 
> Learn how: https://pris.ly/d/vercel-build

This PR ensures that the Prisma client is generated on every Vercel deployment.